### PR TITLE
Feat: add API endpoint for LLMs

### DIFF
--- a/app/components/token/ApiUrlsCard.vue
+++ b/app/components/token/ApiUrlsCard.vue
@@ -1,0 +1,112 @@
+<template>
+    <UCard>
+        <template #header>
+            <button type="button" class="w-full flex items-center justify-between text-left" @click="isOpen = !isOpen">
+                <div class="flex flex-col gap-1">
+                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        API Endpoints
+                    </span>
+                    <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        Webhook and automation URLs
+                    </span>
+                </div>
+                <UIcon :name="isOpen ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+                    class="h-5 w-5 text-gray-500 dark:text-gray-400" />
+            </button>
+        </template>
+
+        <div v-if="isOpen" class="flex flex-col gap-4 p-4 border-t border-gray-200 dark:border-gray-700">
+            <!-- Payload URL -->
+            <div class="space-y-2">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Webhook URL
+                </label>
+                <div class="flex gap-2">
+                    <UInput :model-value="payloadUrl" readonly size="md" class="flex-1 font-mono text-xs" />
+                    <UTooltip :text="copyPayloadState === 'copied' ? 'Copied!' : 'Copy URL'">
+                        <UButton 
+                            :icon="copyPayloadState === 'copied' ? 'i-lucide-check' : 'i-lucide-copy'"
+                            color="neutral" 
+                            variant="soft"
+                            @click="handleCopyPayload" />
+                    </UTooltip>
+                </div>
+                <p class="text-xs text-gray-500 dark:text-gray-400">
+                    Use this URL to capture requests.
+                </p>
+            </div>
+
+            <!-- View API URL -->
+            <div class="space-y-2">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Automation API URL
+                </label>
+                <div class="flex gap-2">
+                    <UInput :model-value="viewUrl" readonly size="md" class="flex-1 font-mono text-xs" />
+                    <UTooltip :text="copyViewState === 'copied' ? 'Copied!' : 'Copy URL'">
+                        <UButton 
+                            :icon="copyViewState === 'copied' ? 'i-lucide-check' : 'i-lucide-copy'"
+                            color="neutral" 
+                            variant="soft"
+                            @click="handleCopyView" />
+                    </UTooltip>
+                </div>
+                <p class="text-xs text-gray-500 dark:text-gray-400">
+                    Read-only API for automation/LLMs. Returns all requests with bodies in JSON format.
+                </p>
+            </div>
+        </div>
+    </UCard>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { notify } from '~/composables/useNotificationBridge'
+import { useTokensStore } from '~/stores/tokens'
+import { copyText } from '~/utils'
+
+const props = defineProps<{ tokenId: string }>()
+
+const tokensStore = useTokensStore()
+const { data: token } = tokensStore.useToken(computed(() => props.tokenId))
+
+const isOpen = usePersistedState('api-urls-open', false)
+const copyPayloadState = ref<'idle' | 'copied'>('idle')
+const copyViewState = ref<'idle' | 'copied'>('idle')
+
+const origin = computed(() => typeof window !== 'undefined' ? window.location.origin : '')
+
+const payloadUrl = computed(() => {
+    const friendlyId = token.value?.friendlyId || ''
+    return `${origin.value}/api/payload/${friendlyId}`
+})
+
+const viewUrl = computed(() => {
+    const friendlyId = token.value?.friendlyId || ''
+    return `${origin.value}/api/view/${friendlyId}?secret=${props.tokenId}`
+})
+
+const handleCopyPayload = async () => {
+    try {
+        await copyText(payloadUrl.value)
+        copyPayloadState.value = 'copied'
+        notify({ title: 'Webhook URL copied', description: payloadUrl.value, variant: 'success' })
+        setTimeout(() => copyPayloadState.value = 'idle', 1200)
+    } catch (error) {
+        console.error('Failed to copy URL:', error)
+        notify({ title: 'Failed to copy URL', variant: 'error' })
+    }
+}
+
+const handleCopyView = async () => {
+    try {
+        await copyText(viewUrl.value)
+        copyViewState.value = 'copied'
+        notify({ title: 'API URL copied', description: viewUrl.value, variant: 'success' })
+        setTimeout(() => copyViewState.value = 'idle', 1200)
+    } catch (error) {
+        console.error('Failed to copy URL:', error)
+        notify({ title: 'Failed to copy URL', variant: 'error' })
+    }
+}
+</script>

--- a/app/pages/token/[id].vue
+++ b/app/pages/token/[id].vue
@@ -32,6 +32,7 @@
             </div>
           </div>
           <div class="grid gap-6 px-6 pb-6 lg:p-6">
+            <ApiUrlsCard :token-id="tokenId" />
             <ResponseSettingsCard :token-id="tokenId" />
             <RawRequestCard :request="selectedRequest" :request-number="selectedRequestNumber" :token-id="tokenId" />
             <RequestDetailsCard :request="selectedRequest" :request-number="selectedRequestNumber"
@@ -59,6 +60,7 @@ import { useSSE } from '~/composables/useSSE'
 import type { SSEEventPayload, RequestSummary } from '~~/shared/types'
 import { notify } from '~/composables/useNotificationBridge'
 import RequestSidebar from '~/components/RequestSidebar.vue'
+import ApiUrlsCard from '~/components/token/ApiUrlsCard.vue'
 import ResponseSettingsCard from '~/components/token/ResponseSettingsCard.vue'
 import RequestDetailsCard from '~/components/token/RequestDetailsCard.vue'
 import RawRequestCard from '~/components/token/RawRequestCard.vue'

--- a/server/api/view/[shortId].ts
+++ b/server/api/view/[shortId].ts
@@ -1,0 +1,159 @@
+import { defineEventHandler, getQuery, createError, type H3Event, type EventHandlerRequest } from 'h3'
+import { useDatabase } from '~~/server/lib/db'
+import { isUUID } from '~~/server/lib/utils'
+import type { Request } from '~~/shared/types'
+
+/**
+ * LLM-friendly request data format
+ */
+interface LLMRequest {
+  id: string
+  method: string
+  url: string
+  headers: Record<string, string>
+  contentType: string
+  contentLength: number
+  isBinary: boolean
+  body: string | null
+  clientIp: string
+  remoteIp: string
+  createdAt: string
+}
+
+/**
+ * LLM-friendly API response
+ */
+interface LLMResponse {
+  token: {
+    id: string
+    friendlyId: string | null
+    createdAt: string
+    payloadUrl: string
+  }
+  requests: LLMRequest[]
+  total: number
+}
+
+/**
+ * Convert Request to LLM-friendly format with body content
+ */
+const formatRequestForLLM = async (request: Request, db: ReturnType<typeof useDatabase>): Promise<LLMRequest> => {
+  let parsedHeaders: Record<string, string> = {}
+  try {
+    parsedHeaders = JSON.parse(request.headers)
+  } catch {
+    parsedHeaders = {}
+  }
+
+  let bodyContent: string | null = null
+  if (request.bodyPath && request.contentLength > 0) {
+    if (request.isBinary) {
+      bodyContent = '[Binary data not included]'
+    } else {
+      const bodyBuffer = await db.requests.getBody(request.sessionId, request.tokenId, request.id)
+      if (bodyBuffer) {
+        try {
+          bodyContent = new TextDecoder('utf-8').decode(bodyBuffer)
+        } catch {
+          bodyContent = '[Unable to decode body as text]'
+        }
+      }
+    }
+  }
+
+  return {
+    id: request.id,
+    method: request.method,
+    url: request.url,
+    headers: parsedHeaders,
+    contentType: request.contentType,
+    contentLength: request.contentLength,
+    isBinary: request.isBinary,
+    body: bodyContent,
+    clientIp: request.clientIp,
+    remoteIp: request.remoteIp,
+    createdAt: request.createdAt.toISOString(),
+  }
+}
+
+/**
+ * API endpoint for automation/LLM access to token requests
+ * 
+ * URL: /api/view/{friendlyId}?secret={tokenUUID}
+ * 
+ * - friendlyId: The 8-character short ID of the token
+ * - secret: Must be the full token UUID (token.id) for authentication
+ * 
+ * Returns LLM-friendly JSON with all requests and their bodies
+ */
+export default defineEventHandler(async (event: H3Event<EventHandlerRequest>) => {
+  const method = event.node.req.method?.toUpperCase() || 'GET'
+  
+  if ('GET' !== method) {
+    throw createError({ statusCode: 405, message: 'Method not allowed' })
+  }
+
+  type EventContextParams = { params?: Record<string, string> }
+  const ctx = (event.context as unknown as EventContextParams) || {}
+  const params = ctx.params || {}
+  const shortId = params.shortId
+
+  if (!shortId) {
+    throw createError({ statusCode: 400, message: 'Short ID is required' })
+  }
+
+  const query = getQuery(event)
+  const secret = query.secret as string | undefined
+
+  if (!secret) {
+    throw createError({ statusCode: 401, message: 'Secret parameter is required' })
+  }
+
+  // Secret must be a valid UUID
+  if (!isUUID(secret)) {
+    throw createError({ statusCode: 401, message: 'Invalid secret format' })
+  }
+
+  const db = useDatabase()
+  
+  // Only accept friendlyId (short ID) in the URL path
+  const token = await db.tokens.getByFriendlyId(shortId)
+  if (!token) {
+    throw createError({ statusCode: 404, message: 'Token not found' })
+  }
+
+  // Verify that the secret matches the token ID
+  if (token.id !== secret) {
+    throw createError({ statusCode: 403, message: 'Invalid secret' })
+  }
+
+  // Fetch all requests for this token
+  const requests = await db.requests.list(token.sessionId, token.id)
+
+  // Format requests for LLM consumption
+  const formattedRequests: LLMRequest[] = []
+  for (const request of requests) {
+    const formatted = await formatRequestForLLM(request, db)
+    formattedRequests.push(formatted)
+  }
+
+  // Build payload URL for webhook ingestion
+  // Try to get from request headers, fallback to config or localhost
+  const host = event.node.req.headers.host || 'localhost:3000'
+  const protocol = event.node.req.headers['x-forwarded-proto'] || 'http'
+  const baseUrl = `${protocol}://${host}`
+  const payloadUrl = `${baseUrl}/api/payload/${token.friendlyId || token.id}`
+
+  const response: LLMResponse = {
+    token: {
+      id: token.id,
+      friendlyId: token.friendlyId,
+      createdAt: token.createdAt.toISOString(),
+      payloadUrl,
+    },
+    requests: formattedRequests,
+    total: formattedRequests.length,
+  }
+
+  return response
+})

--- a/test/integration/view-api.spec.ts
+++ b/test/integration/view-api.spec.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import createH3Event from '../utils/createH3Event'
+import type { H3Event } from 'h3'
+import type { Token, Request } from '../../shared/types'
+
+// Mock getQuery from h3 to parse URL query strings
+vi.mock('h3', async () => {
+  const actual = await vi.importActual<typeof import('h3')>('h3')
+  return {
+    ...actual,
+    getQuery: vi.fn((event: H3Event) => {
+      const url = event.node.req.url || ''
+      const queryString = url.split('?')[1] || ''
+      const params: Record<string, string> = {}
+      if (queryString) {
+        const pairs = queryString.split('&')
+        for (const pair of pairs) {
+          const [key, value] = pair.split('=')
+          if (key) {
+            params[key] = decodeURIComponent(value || '')
+          }
+        }
+      }
+      return params
+    }),
+  }
+})
+
+// Mock data
+const mockToken: Token = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  friendlyId: 'abc123xy',
+  sessionId: '650e8400-e29b-41d4-a716-446655440001',
+  createdAt: new Date('2024-01-01'),
+  responseEnabled: false,
+  responseStatus: 200,
+  responseHeaders: null,
+  responseBody: null,
+}
+
+const mockRequests: Request[] = [
+  {
+    id: '750e8400-e29b-41d4-a716-446655440002',
+    tokenId: '550e8400-e29b-41d4-a716-446655440000',
+    sessionId: '650e8400-e29b-41d4-a716-446655440001',
+    method: 'POST',
+    url: 'https://example.com/test',
+    headers: JSON.stringify({ 'Content-Type': 'application/json', 'User-Agent': 'test' }),
+    contentType: 'application/json',
+    contentLength: 15,
+    isBinary: false,
+    clientIp: '127.0.0.1',
+    remoteIp: '127.0.0.1',
+    bodyPath: 'session-123/token-uuid-123/req-1',
+    createdAt: new Date('2024-01-01T10:00:00Z'),
+  },
+  {
+    id: '850e8400-e29b-41d4-a716-446655440003',
+    tokenId: '550e8400-e29b-41d4-a716-446655440000',
+    sessionId: '650e8400-e29b-41d4-a716-446655440001',
+    method: 'POST',
+    url: 'https://example.com/image',
+    headers: JSON.stringify({ 'Content-Type': 'image/png' }),
+    contentType: 'image/png',
+    contentLength: 6,
+    isBinary: true,
+    clientIp: '127.0.0.1',
+    remoteIp: '127.0.0.1',
+    bodyPath: 'session-123/token-uuid-123/req-2',
+    createdAt: new Date('2024-01-01T11:00:00Z'),
+  },
+]
+
+// Mock database operations
+const mockGetByFriendlyId = vi.fn(async (friendlyId: string): Promise<Token | null> => {
+  if (friendlyId === mockToken.friendlyId) {
+    return mockToken
+  }
+  return null
+})
+
+const mockGetSessionId = vi.fn(async (tokenId: string): Promise<string | null> => {
+  if (tokenId === mockToken.id) {
+    return mockToken.sessionId
+  }
+  return null
+})
+
+const mockGetToken = vi.fn(async (sessionId: string, tokenId: string): Promise<Token | null> => {
+  if (sessionId === mockToken.sessionId && tokenId === mockToken.id) {
+    return mockToken
+  }
+  return null
+})
+
+const mockListRequests = vi.fn(async (_sessionId: string, _tokenId: string): Promise<Request[]> => {
+  return mockRequests
+})
+
+const mockGetBody = vi.fn(async (sessionId: string, tokenId: string, requestId: string): Promise<Uint8Array | null> => {
+  if (requestId === '750e8400-e29b-41d4-a716-446655440002') {
+    return new TextEncoder().encode('{"test":"data"}')
+  }
+  if (requestId === '850e8400-e29b-41d4-a716-446655440003') {
+    return new Uint8Array([0x89, 0x50, 0x4E, 0x47])
+  }
+  return null
+})
+
+vi.mock('~~/server/lib/db', () => ({
+  useDatabase: () => ({
+    tokens: {
+      getByFriendlyId: mockGetByFriendlyId,
+      getSessionId: mockGetSessionId,
+      get: mockGetToken,
+    },
+    requests: {
+      list: mockListRequests,
+      getBody: mockGetBody,
+    },
+  }),
+}))
+
+// Helper to create test event with proper headers
+const createTestEvent = (overrides: Parameters<typeof createH3Event>[0]) => {
+  return createH3Event({
+    ...overrides,
+    node: {
+      ...overrides?.node,
+      req: {
+        ...overrides?.node?.req,
+        headers: {
+          host: 'localhost:3000',
+          ...overrides?.node?.req?.headers,
+        },
+      },
+    },
+  })
+}
+
+describe('GET /api/view/[shortId]', () => {
+  let handler: (event: H3Event) => Promise<unknown>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    handler = (await import('../../server/api/view/[shortId]')).default
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Authentication', () => {
+    it('should require secret parameter', async () => {
+      const url = `/api/view/${mockToken.friendlyId}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      await expect(handler(event)).rejects.toThrow('Secret parameter is required')
+    })
+
+    it('should reject invalid secret format', async () => {
+      const url = `/api/view/${mockToken.friendlyId}?secret=invalid`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      await expect(handler(event)).rejects.toThrow('Invalid secret format')
+    })
+
+    it('should reject wrong secret (UUID mismatch)', async () => {
+      const wrongSecret = '00000000-0000-0000-0000-000000000000'
+      const url = `/api/view/${mockToken.friendlyId}?secret=${wrongSecret}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      await expect(handler(event)).rejects.toThrow('Invalid secret')
+    })
+
+    it('should accept correct secret', async () => {
+      const url = `/api/view/${mockToken.friendlyId}?secret=${mockToken.id}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      const result = await handler(event)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('Token lookup', () => {
+    it('should work with friendlyId', async () => {
+      const url = `/api/view/${mockToken.friendlyId}?secret=${mockToken.id}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      const result = await handler(event) as { token: { id: string; friendlyId: string | null } }
+      expect(result.token.id).toBe(mockToken.id)
+      expect(result.token.friendlyId).toBe(mockToken.friendlyId)
+      expect(mockGetByFriendlyId).toHaveBeenCalledWith(mockToken.friendlyId)
+    })
+
+    it('should return 404 for non-existent token', async () => {
+      const url = `/api/view/notfound?secret=${mockToken.id}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: 'notfound' } },
+        node: { req: { url } },
+      })
+
+      await expect(handler(event)).rejects.toThrow('Token not found')
+    })
+  })
+
+  describe('Response format', () => {
+    it('should return LLM-friendly JSON structure', async () => {
+      const url = `/api/view/${mockToken.friendlyId}?secret=${mockToken.id}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      const result = await handler(event) as {
+        token: { id: string; friendlyId: string | null; createdAt: string; payloadUrl: string }
+        requests: unknown[]
+        total: number
+      }
+
+      // Check top-level structure
+      expect(result).toHaveProperty('token')
+      expect(result).toHaveProperty('requests')
+      expect(result).toHaveProperty('total')
+
+      // Check token structure
+      expect(result.token).toHaveProperty('id')
+      expect(result.token).toHaveProperty('friendlyId')
+      expect(result.token).toHaveProperty('createdAt')
+      expect(result.token).toHaveProperty('payloadUrl')
+      expect(typeof result.token.createdAt).toBe('string')
+      expect(typeof result.token.payloadUrl).toBe('string')
+      expect(result.token.payloadUrl).toContain('/api/payload/')
+
+      // Check requests is array
+      expect(Array.isArray(result.requests)).toBe(true)
+      expect(result.total).toBe(result.requests.length)
+    })
+  })
+
+  describe('Request data', () => {
+    it('should include request details', async () => {
+      const url = `/api/view/${mockToken.friendlyId}?secret=${mockToken.id}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      const result = await handler(event) as { requests: Array<{
+        id: string
+        method: string
+        url: string
+        headers: Record<string, string>
+        contentType: string
+        contentLength: number
+        isBinary: boolean
+        body: string | null
+        clientIp: string
+        remoteIp: string
+        createdAt: string
+      }> }
+
+      expect(result.requests.length).toBeGreaterThan(0)
+
+      const request = result.requests[0]
+      expect(request).toHaveProperty('id')
+      expect(request).toHaveProperty('method')
+      expect(request).toHaveProperty('url')
+      expect(request).toHaveProperty('headers')
+      expect(request).toHaveProperty('contentType')
+      expect(request).toHaveProperty('contentLength')
+      expect(request).toHaveProperty('isBinary')
+      expect(request).toHaveProperty('body')
+      expect(request).toHaveProperty('clientIp')
+      expect(request).toHaveProperty('remoteIp')
+      expect(request).toHaveProperty('createdAt')
+
+      expect(typeof request.headers).toBe('object')
+      expect(typeof request.createdAt).toBe('string')
+    })
+
+    it('should include text body content', async () => {
+      const url = `/api/view/${mockToken.friendlyId}?secret=${mockToken.id}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      const result = await handler(event) as { requests: Array<{ contentType: string; body: string }> }
+
+      const textRequest = result.requests.find(r => r.contentType === 'application/json')
+
+      expect(textRequest).toBeDefined()
+      expect(textRequest?.body).toContain('test')
+      expect(textRequest?.body).toContain('data')
+    })
+
+    it('should mark binary content appropriately', async () => {
+      const url = `/api/view/${mockToken.friendlyId}?secret=${mockToken.id}`
+      
+      const event = createTestEvent({
+        context: { params: { shortId: mockToken.friendlyId } },
+        node: { req: { url } },
+      })
+
+      const result = await handler(event) as { requests: Array<{ contentType: string; isBinary: boolean; body: string }> }
+
+      const binaryRequest = result.requests.find(r => r.contentType === 'image/png')
+
+      expect(binaryRequest).toBeDefined()
+      expect(binaryRequest?.isBinary).toBe(true)
+      expect(binaryRequest?.body).toBe('[Binary data not included]')
+    })
+  })
+
+  describe('Method restrictions', () => {
+    it('should only accept GET requests', async () => {
+      const methods = ['POST', 'PUT', 'PATCH', 'DELETE']
+
+      for (const method of methods) {
+        const url = `/api/view/${mockToken.friendlyId}?secret=${mockToken.id}`
+        
+        const event = createTestEvent({
+          context: { params: { shortId: mockToken.friendlyId } },
+          node: { req: { url, method } },
+        })
+
+        await expect(handler(event)).rejects.toThrow('Method not allowed')
+      }
+    })
+  })
+})
+


### PR DESCRIPTION
This pull request introduces a new LLM/automation-friendly API endpoint for accessing token request data, adds a corresponding UI card to display and copy relevant API URLs, and provides comprehensive integration tests to ensure correct behavior and security. The changes improve both backend automation capabilities and frontend user experience for API consumers.

**API endpoint for LLM/automation:**

- Added a new endpoint at `/api/view/[shortId]?secret={tokenUUID}` that returns all requests for a token in a structured JSON format, including request bodies (as text or a placeholder for binary data), headers, and metadata. The endpoint requires both the token's short ID and its UUID as a secret for authentication, and only supports GET requests. ([server/api/view/[shortId].tsR1-R159](diffhunk://#diff-9dfbb35b3aa74d75cf11d8e392c6569dd741984425561d2a17390d1617883064R1-R159))

**Frontend enhancements:**

- Introduced a new `ApiUrlsCard.vue` component that displays the Webhook and Automation API URLs for a token, with copy-to-clipboard functionality and tooltips for user feedback.
- Integrated the new `ApiUrlsCard` into the token details page (`[id].vue`) so users can easily access and copy the relevant API endpoints. ([app/pages/token/[id].vueR35](diffhunk://#diff-b39ec7cd59d67aff4933c6779907f98fe327cdc42a50aad49d19109593f927deR35), [app/pages/token/[id].vueR63](diffhunk://#diff-b39ec7cd59d67aff4933c6779907f98fe327cdc42a50aad49d19109593f927deR63))

**Testing and reliability:**

- Added a comprehensive integration test suite (`view-api.spec.ts`) covering authentication, token lookup, response format, request data inclusion, binary/text body handling, and method restrictions for the new API endpoint.